### PR TITLE
Make command name include verb "Show" for consistency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,8 +138,8 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.open, {
-      label: 'Dev Tools Console Logs',
-      caption: 'Dev Tools Console Logs',
+      label: 'Show Dev Tools Console Logs',
+      caption: 'Show Dev Tools Console Logs',
       isToggled: () => logConsoleWidget !== null,
       execute: () => {
         if (logConsoleWidget) {


### PR DESCRIPTION
Other items with a toggle for showing in JLab always start with the verb "Show", as in "Show Log Console". Then the checkmark next to the command is more meaningful.

https://github.com/jupyterlab/jupyterlab/blob/f7c86cccd848c1c0858ec0e2a4da629065f8a924/packages/logconsole-extension/src/index.tsx#L191