### PR TITLE
Remove circular references when stringifying an object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,13 +169,32 @@ const extension: JupyterFrontEndPlugin<void> = {
     const _trace = console.trace;
     const _table = console.table;
 
+    // https://stackoverflow.com/a/11616993
+    // We need to clear cache after each use.
+    let cache: any = [];
+    const refReplacer = (key: any, value: any) => {
+      if (typeof value === 'object' && value !== null) {
+          if (cache.indexOf(value) !== -1) {
+              return;
+          }
+          cache.push(value);
+      }
+      return value;
+    };
+    
+
     window.console.debug = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({
@@ -189,10 +208,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     window.console.log = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({
@@ -206,10 +230,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     window.console.info = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({
@@ -223,10 +252,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     window.console.warn = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({
@@ -240,10 +274,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     window.console.error = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({
@@ -257,10 +296,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     window.console.exception = (message?: string, ...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({
@@ -274,10 +318,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     window.console.trace = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({
@@ -291,10 +340,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     window.console.table = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
-        data +=
+        try {
+          data +=
           (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg)
+            ? JSON.stringify(arg, refReplacer)
             : arg) + ' ';
+          cache = [];
+        } catch (error) {
+          data += ' ';
+        }
       });
 
       logConsolePanel?.logger?.log({

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,11 +188,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 
@@ -210,11 +218,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 
@@ -232,11 +248,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 
@@ -254,11 +278,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 
@@ -276,11 +308,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 
@@ -298,11 +338,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 
@@ -320,11 +368,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 
@@ -342,11 +398,19 @@ const extension: JupyterFrontEndPlugin<void> = {
         try {
           data +=
             (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg, refReplacer)
+              ? JSON.stringify(arg)
               : arg) + ' ';
-          cache = [];
-        } catch (error) {
-          data += ' ';
+        } catch (e) {
+          try {
+            const msg =
+              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+            const obj = JSON.stringify(arg, refReplacer);
+            cache = [];
+            console.error(msg, obj);
+            data += obj;
+          } catch (e) {
+            data += ' ';
+          }
         }
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       return value;
     };
 
-    window.console.debug = (...args: any[]): void => {
+    const parseArgs = (args: any[]): string => {
       let data = '';
       args.forEach(arg => {
         try {
@@ -203,221 +203,77 @@ const extension: JupyterFrontEndPlugin<void> = {
           }
         }
       });
+      return data;
+    };
 
+    window.console.debug = (...args: any[]): void => {
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'debug',
-        data
+        data: parseArgs(args)
       });
       _debug(...args);
     };
 
     window.console.log = (...args: any[]): void => {
-      let data = '';
-      args.forEach(arg => {
-        try {
-          data +=
-            (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg)
-              : arg) + ' ';
-        } catch (e) {
-          try {
-            const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
-            const obj = JSON.stringify(arg, refReplacer);
-            cache = [];
-            console.error(msg, obj);
-            data += obj;
-          } catch (e) {
-            data += ' ';
-          }
-        }
-      });
-
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'debug',
-        data
+        data: parseArgs(args)
       });
       _log(...args);
     };
 
     window.console.info = (...args: any[]): void => {
-      let data = '';
-      args.forEach(arg => {
-        try {
-          data +=
-            (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg)
-              : arg) + ' ';
-        } catch (e) {
-          try {
-            const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
-            const obj = JSON.stringify(arg, refReplacer);
-            cache = [];
-            console.error(msg, obj);
-            data += obj;
-          } catch (e) {
-            data += ' ';
-          }
-        }
-      });
-
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'info',
-        data
+        data: parseArgs(args)
       });
       _info(...args);
     };
 
     window.console.warn = (...args: any[]): void => {
-      let data = '';
-      args.forEach(arg => {
-        try {
-          data +=
-            (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg)
-              : arg) + ' ';
-        } catch (e) {
-          try {
-            const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
-            const obj = JSON.stringify(arg, refReplacer);
-            cache = [];
-            console.error(msg, obj);
-            data += obj;
-          } catch (e) {
-            data += ' ';
-          }
-        }
-      });
-
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'warning',
-        data
+        data: parseArgs(args)
       });
       _warn(...args);
     };
 
     window.console.error = (...args: any[]): void => {
-      let data = '';
-      args.forEach(arg => {
-        try {
-          data +=
-            (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg)
-              : arg) + ' ';
-        } catch (e) {
-          try {
-            const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
-            const obj = JSON.stringify(arg, refReplacer);
-            cache = [];
-            console.error(msg, obj);
-            data += obj;
-          } catch (e) {
-            data += ' ';
-          }
-        }
-      });
-
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'critical',
-        data
+        data: parseArgs(args)
       });
       _error(...args);
     };
 
     window.console.exception = (message?: string, ...args: any[]): void => {
-      let data = '';
-      args.forEach(arg => {
-        try {
-          data +=
-            (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg)
-              : arg) + ' ';
-        } catch (e) {
-          try {
-            const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
-            const obj = JSON.stringify(arg, refReplacer);
-            cache = [];
-            console.error(msg, obj);
-            data += obj;
-          } catch (e) {
-            data += ' ';
-          }
-        }
-      });
-
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'critical',
-        data: `Exception: ${message}\n${data}`
+        data: `Exception: ${message}\n${parseArgs(args)}`
       });
       _exception(...args);
     };
 
     window.console.trace = (...args: any[]): void => {
-      let data = '';
-      args.forEach(arg => {
-        try {
-          data +=
-            (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg)
-              : arg) + ' ';
-        } catch (e) {
-          try {
-            const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
-            const obj = JSON.stringify(arg, refReplacer);
-            cache = [];
-            console.error(msg, obj);
-            data += obj;
-          } catch (e) {
-            data += ' ';
-          }
-        }
-      });
-
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'info',
-        data
+        data: parseArgs(args)
       });
       _trace(...args);
     };
 
     window.console.table = (...args: any[]): void => {
-      let data = '';
-      args.forEach(arg => {
-        try {
-          data +=
-            (typeof arg === 'object' && arg !== null
-              ? JSON.stringify(arg)
-              : arg) + ' ';
-        } catch (e) {
-          try {
-            const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
-            const obj = JSON.stringify(arg, refReplacer);
-            cache = [];
-            console.error(msg, obj);
-            data += obj;
-          } catch (e) {
-            data += ' ';
-          }
-        }
-      });
-
       logConsolePanel?.logger?.log({
         type: 'text',
         level: 'info',
-        data
+        data: parseArgs(args)
       });
       _table(...args);
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,23 +174,22 @@ const extension: JupyterFrontEndPlugin<void> = {
     let cache: any = [];
     const refReplacer = (key: any, value: any) => {
       if (typeof value === 'object' && value !== null) {
-          if (cache.indexOf(value) !== -1) {
-              return;
-          }
-          cache.push(value);
+        if (cache.indexOf(value) !== -1) {
+          return;
+        }
+        cache.push(value);
       }
       return value;
     };
-    
 
     window.console.debug = (...args: any[]): void => {
       let data = '';
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';
@@ -210,9 +209,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';
@@ -232,9 +231,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';
@@ -254,9 +253,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';
@@ -276,9 +275,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';
@@ -298,9 +297,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';
@@ -320,9 +319,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';
@@ -342,9 +341,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       args.forEach(arg => {
         try {
           data +=
-          (typeof arg === 'object' && arg !== null
-            ? JSON.stringify(arg, refReplacer)
-            : arg) + ' ';
+            (typeof arg === 'object' && arg !== null
+              ? JSON.stringify(arg, refReplacer)
+              : arg) + ' ';
           cache = [];
         } catch (error) {
           data += ' ';

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         } catch (e) {
           try {
             const msg =
-              'This error contains a object with a circular reference. During the process of removing the reference we could have removed duplicated attributes.\n';
+              'This error contains a object with a circular reference. Duplicated attributes might have been dropped during the process of removing the reference.\n';
             const obj = JSON.stringify(arg, refReplacer);
             cache = [];
             console.error(msg, obj);


### PR DESCRIPTION
Remove circular references when stringifying an object because otherwise, the `JSON.stringify` throws an error.