### PR TITLE
Automated Changelog Entry for 2.2.3 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.2.2
+## 2.2.3
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/0.2.2...14e59dc4e5d15a3a6246d8bb1967e18fddac9b10))
+
+### Bugs fixed
+
+- Remove circular references when stringifying an object [#11](https://github.com/QuantStack/jupyterlab-js-logs/pull/11) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Add `publishConfig` to `package.json` [#13](https://github.com/QuantStack/jupyterlab-js-logs/pull/13) ([@jtpio](https://github.com/jtpio))
+- Add github action to check release [#12](https://github.com/QuantStack/jupyterlab-js-logs/pull/12) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-08-06&to=2021-09-14&type=c))
+
+[@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ahbcarlos+updated%3A2021-08-06..2021-09-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ajtpio+updated%3A2021-08-06..2021-09-14&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.2.2


### PR DESCRIPTION
Automated Changelog Entry for 2.2.3 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | QuantStack/jupyterlab-js-logs  |
| Branch  | main  |
| Version Spec | 2.2.3 |
| Since | 0.2.2 |