### PR TITLE
Update Binder link to point to the `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyterlab-js-logs
 
 ![Github Actions Status](https://github.com/QuantStack/jupyterlab-js-logs/workflows/Build/badge.svg)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-js-logs/master?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-js-logs/main?urlpath=lab)
 
 JupyterLab extension to show the js logs from the browser dev tools console
 


### PR DESCRIPTION
Follow-up to the rename to `main` in #12 