### PR TITLE
Set name as jupyterlab-js-logs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,10 @@ import setuptools
 HERE = Path(__file__).parent.resolve()
 
 # The name of the project
-name = "jupyterlab_js_logs"
+NAME = "jupyterlab-js-logs"
+PY_NAME = NAME.replace('-', '_')
 
-lab_path = (HERE / name / "labextension")
+lab_path = (HERE / PY_NAME / "labextension")
 
 # Representative files that should exist after a successful build
 ensured_targets = [
@@ -32,7 +33,7 @@ long_description = (HERE / "README.md").read_text()
 pkg_json = json.loads((HERE / "package.json").read_bytes())
 
 setup_args = dict(
-    name=name,
+    name=NAME,
     version=pkg_json["version"],
     url=pkg_json["homepage"],
     author=pkg_json["author"]["name"],


### PR DESCRIPTION
Keep the name as `jupyterlab-js-logs`