### PR TITLE
Automated Changelog Entry for 0.2.5 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.5
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/v0.2.4...2b893318a9ee85a3c649fcb92f1ded9ba732a00d))
+
+### Merged PRs
+
+- Build js in prod mode for the release [#20](https://github.com/QuantStack/jupyterlab-js-logs/pull/20) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-09-15&to=2022-01-21&type=c))
+
+[@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ahbcarlos+updated%3A2021-09-15..2022-01-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.4
 
 ([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/v0.2.3...62cef996ed0c8434147907aa3a8bdb7bf6ffc9a6))
@@ -19,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-09-14&to=2021-09-15&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ajtpio+updated%3A2021-09-14..2021-09-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.2.3
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.5 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | QuantStack/jupyterlab-js-logs  |
| Branch  | main  |
| Version Spec | 0.2.5 |
| Since | v0.2.4 |