### PR TITLE
Expose log entry actions, add copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,45 @@ The extension exposes two settings in JupyterLab Settings Editor (`JS Logs`):
 - `defaultLevel`: default log level when opening the JS Logs panel. Default: `info`.
 - `showLevelChangeMessages`: whether to show metadata messages when log level changes. Default: `false`.
 
+## Extension point: log entry actions
+
+This package provides an `ILogEntryActionRegistry` token for adding user-triggered actions to log rows in the JS Logs panel.
+
+Actions are only executed when a user clicks a button. The extension does not automatically send log data anywhere.
+
+Notes:
+
+- Action `id` must be unique across all registered actions.
+- `register(...)` returns a disposable you can call to remove the action.
+- Buttons are rendered inline in each matching log row (inside the output content area, below the row text).
+- `execute(message)` receives `{ source, entryIndex, level, timestamp, text, output }`.
+
+```ts
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import { ILogEntryActionRegistry } from 'jupyterlab-js-logs';
+
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'my-log-actions',
+  autoStart: true,
+  requires: [ILogEntryActionRegistry],
+  activate: (_app: JupyterFrontEnd, actions: ILogEntryActionRegistry) => {
+    actions.register({
+      id: 'my-actions:copy-log-context',
+      label: 'Copy Context',
+      caption: 'Run a custom action with this log entry',
+      isVisible: message => ['error', 'critical'].includes(message.level),
+      execute: message => {
+        // Use the selected row context in your integration.
+        console.log('Selected log entry:', message);
+      }
+    });
+  }
+};
+```
+
 ## Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Notes:
 - Action `id` must be unique across all registered actions.
 - `register(...)` returns a disposable you can call to remove the action.
 - Buttons are rendered inline in each matching log row (inside the output content area, below the row text).
-- `execute(message)` receives `{ source, entryIndex, level, timestamp, text, output }`.
+- `execute(message)` receives `{ source, entryIndex, level, timestamp, output }`.
+- This extension ships with a default `Copy` action on log rows as an example consumer of this API.
 
 ```ts
 import {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Notes:
 
 - Action `id` must be unique across all registered actions.
 - `register(...)` returns a disposable you can call to remove the action.
-- Buttons are rendered inline in each matching log row (inside the output content area, below the row text).
+- Buttons are rendered inline in each matching log row (at the right side of the row content).
+- Actions can optionally provide an `icon` (for example from `@jupyterlab/ui-components`).
 - `execute(message)` receives `{ source, entryIndex, level, timestamp, output }`.
 - This extension ships with a default `Copy` action on log rows as an example consumer of this API.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,12 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
-import { addIcon, clearIcon, LabIcon } from '@jupyterlab/ui-components';
+import {
+  addIcon,
+  clearIcon,
+  copyIcon,
+  LabIcon
+} from '@jupyterlab/ui-components';
 
 import { Token } from '@lumino/coreutils';
 
@@ -108,7 +113,7 @@ const defaultLogEntryActionsExtension: JupyterFrontEndPlugin<void> = {
   ) => {
     actionRegistry.register({
       id: 'jupyterlab-js-logs:copy-log-entry',
-      label: 'Copy',
+      icon: copyIcon,
       caption: 'Copy this log entry context',
       execute: message => {
         Clipboard.copyToSystem(formatLogEntryForClipboard(message));

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,15 +93,27 @@ const logEntryActionsExtension: JupyterFrontEndPlugin<ILogEntryActionRegistry> =
     activate: () => new LogEntryActionRegistry()
   };
 
-const formatLogEntryForClipboard = (message: ILogEntryActionMessage): string =>
-  JSON.stringify(
-    {
-      ...message,
-      timestamp: message.timestamp ? message.timestamp.toISOString() : null
-    },
-    null,
-    2
-  );
+const getLogEntryMessageText = (message: ILogEntryActionMessage): string => {
+  const rawData = message.output.data;
+  if (
+    typeof rawData !== 'object' ||
+    rawData === null ||
+    Array.isArray(rawData)
+  ) {
+    return '';
+  }
+  const data = rawData as Record<string, unknown>;
+  const text = data['text/plain'];
+
+  if (typeof text === 'string') {
+    return text.trim();
+  }
+  if (Array.isArray(text) && text.every(item => typeof item === 'string')) {
+    return text.join('').trim();
+  }
+
+  return '';
+};
 
 const defaultLogEntryActionsExtension: JupyterFrontEndPlugin<void> = {
   id: DEFAULT_ACTIONS_PLUGIN_ID,
@@ -114,9 +126,9 @@ const defaultLogEntryActionsExtension: JupyterFrontEndPlugin<void> = {
     actionRegistry.register({
       id: 'jupyterlab-js-logs:copy-log-entry',
       icon: copyIcon,
-      caption: 'Copy this log entry context',
+      caption: 'Copy this log message',
       execute: message => {
-        Clipboard.copyToSystem(formatLogEntryForClipboard(message));
+        Clipboard.copyToSystem(getLogEntryMessageText(message));
       }
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@jupyterlab/application';
 
 import {
+  Clipboard,
   ICommandPalette,
   IWidgetTracker,
   MainAreaWidget,
@@ -28,6 +29,7 @@ import { Token } from '@lumino/coreutils';
 
 import {
   LogEntryActionsRenderer,
+  ILogEntryActionMessage,
   ILogEntryActionRegistry,
   LogEntryActionRegistry
 } from './logEntryActions';
@@ -61,6 +63,7 @@ export const ILogConsoleTracker = new Token<ILogConsoleTracker>(
 
 const PLUGIN_ID = 'js-logs';
 const ACTIONS_PLUGIN_ID = 'jupyterlab-js-logs:entry-actions';
+const DEFAULT_ACTIONS_PLUGIN_ID = 'jupyterlab-js-logs:default-entry-actions';
 const SETTINGS_PLUGIN_ID = 'jupyterlab-js-logs:plugin';
 const DEFAULT_LEVEL_SETTING = 'defaultLevel';
 const SHOW_LEVEL_CHANGE_MESSAGES_SETTING = 'showLevelChangeMessages';
@@ -85,6 +88,35 @@ const logEntryActionsExtension: JupyterFrontEndPlugin<ILogEntryActionRegistry> =
     activate: () => new LogEntryActionRegistry()
   };
 
+const formatLogEntryForClipboard = (message: ILogEntryActionMessage): string =>
+  JSON.stringify(
+    {
+      ...message,
+      timestamp: message.timestamp ? message.timestamp.toISOString() : null
+    },
+    null,
+    2
+  );
+
+const defaultLogEntryActionsExtension: JupyterFrontEndPlugin<void> = {
+  id: DEFAULT_ACTIONS_PLUGIN_ID,
+  autoStart: true,
+  requires: [ILogEntryActionRegistry],
+  activate: (
+    _app: JupyterFrontEnd,
+    actionRegistry: ILogEntryActionRegistry
+  ) => {
+    actionRegistry.register({
+      id: 'jupyterlab-js-logs:copy-log-entry',
+      label: 'Copy',
+      caption: 'Copy this log entry context',
+      execute: message => {
+        Clipboard.copyToSystem(formatLogEntryForClipboard(message));
+      }
+    });
+  }
+};
+
 /**
  * The main jupyterlab-js-logs plugin.
  */
@@ -92,20 +124,15 @@ const extension: JupyterFrontEndPlugin<ILogConsoleTracker> = {
   id: PLUGIN_ID,
   autoStart: true,
   provides: ILogConsoleTracker,
-  requires: [IRenderMimeRegistry],
-  optional: [
-    ICommandPalette,
-    ILayoutRestorer,
-    ISettingRegistry,
-    ILogEntryActionRegistry
-  ],
+  requires: [IRenderMimeRegistry, ILogEntryActionRegistry],
+  optional: [ICommandPalette, ILayoutRestorer, ISettingRegistry],
   activate: (
     app: JupyterFrontEnd,
     rendermime: IRenderMimeRegistry,
+    actionRegistry: ILogEntryActionRegistry,
     palette: ICommandPalette | null,
     restorer: ILayoutRestorer | null,
-    settingsRegistry: ISettingRegistry | null,
-    actionRegistry: ILogEntryActionRegistry | null
+    settingsRegistry: ISettingRegistry | null
   ) => {
     const { commands } = app;
 
@@ -205,13 +232,11 @@ const extension: JupyterFrontEndPlugin<ILogConsoleTracker> = {
       logConsolePanel.source = 'js-logs';
       connectLevelChangeHandler(logConsolePanel);
 
-      let entryActionRenderer: LogEntryActionsRenderer | null = null;
-      if (actionRegistry) {
-        entryActionRenderer = new LogEntryActionsRenderer({
+      let entryActionRenderer: LogEntryActionsRenderer | null =
+        new LogEntryActionsRenderer({
           panel: logConsolePanel,
           registry: actionRegistry
         });
-      }
 
       logConsoleWidget = new MainAreaWidget<LogConsolePanel>({
         content: logConsolePanel
@@ -449,6 +474,7 @@ const extension: JupyterFrontEndPlugin<ILogConsoleTracker> = {
 
 const plugins: JupyterFrontEndPlugin<any>[] = [
   logEntryActionsExtension,
+  defaultLogEntryActionsExtension,
   extension
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,12 @@ import { addIcon, clearIcon, LabIcon } from '@jupyterlab/ui-components';
 
 import { Token } from '@lumino/coreutils';
 
+import {
+  LogEntryActionsRenderer,
+  ILogEntryActionRegistry,
+  LogEntryActionRegistry
+} from './logEntryActions';
+
 import LogLevelSwitcher from './logLevelSwitcher';
 
 import jsIconStr from '../style/js.svg';
@@ -54,6 +60,7 @@ export const ILogConsoleTracker = new Token<ILogConsoleTracker>(
 );
 
 const PLUGIN_ID = 'js-logs';
+const ACTIONS_PLUGIN_ID = 'jupyterlab-js-logs:entry-actions';
 const SETTINGS_PLUGIN_ID = 'jupyterlab-js-logs:plugin';
 const DEFAULT_LEVEL_SETTING = 'defaultLevel';
 const SHOW_LEVEL_CHANGE_MESSAGES_SETTING = 'showLevelChangeMessages';
@@ -70,6 +77,14 @@ const LOG_LEVELS: LogLevel[] = [
 const isLogLevel = (value: unknown): value is LogLevel =>
   typeof value === 'string' && LOG_LEVELS.includes(value as LogLevel);
 
+const logEntryActionsExtension: JupyterFrontEndPlugin<ILogEntryActionRegistry> =
+  {
+    id: ACTIONS_PLUGIN_ID,
+    autoStart: true,
+    provides: ILogEntryActionRegistry,
+    activate: () => new LogEntryActionRegistry()
+  };
+
 /**
  * The main jupyterlab-js-logs plugin.
  */
@@ -78,13 +93,19 @@ const extension: JupyterFrontEndPlugin<ILogConsoleTracker> = {
   autoStart: true,
   provides: ILogConsoleTracker,
   requires: [IRenderMimeRegistry],
-  optional: [ICommandPalette, ILayoutRestorer, ISettingRegistry],
+  optional: [
+    ICommandPalette,
+    ILayoutRestorer,
+    ISettingRegistry,
+    ILogEntryActionRegistry
+  ],
   activate: (
     app: JupyterFrontEnd,
     rendermime: IRenderMimeRegistry,
     palette: ICommandPalette | null,
     restorer: ILayoutRestorer | null,
-    settingsRegistry: ISettingRegistry | null
+    settingsRegistry: ISettingRegistry | null,
+    actionRegistry: ILogEntryActionRegistry | null
   ) => {
     const { commands } = app;
 
@@ -184,6 +205,14 @@ const extension: JupyterFrontEndPlugin<ILogConsoleTracker> = {
       logConsolePanel.source = 'js-logs';
       connectLevelChangeHandler(logConsolePanel);
 
+      let entryActionRenderer: LogEntryActionsRenderer | null = null;
+      if (actionRegistry) {
+        entryActionRenderer = new LogEntryActionsRenderer({
+          panel: logConsolePanel,
+          registry: actionRegistry
+        });
+      }
+
       logConsoleWidget = new MainAreaWidget<LogConsolePanel>({
         content: logConsolePanel
       });
@@ -217,6 +246,8 @@ const extension: JupyterFrontEndPlugin<ILogConsoleTracker> = {
       );
 
       logConsoleWidget.disposed.connect(() => {
+        entryActionRenderer?.dispose();
+        entryActionRenderer = null;
         logConsoleWidget = null;
         logConsolePanel = null;
         commands.notifyCommandChanged();
@@ -416,4 +447,15 @@ const extension: JupyterFrontEndPlugin<ILogConsoleTracker> = {
   }
 };
 
-export default extension;
+const plugins: JupyterFrontEndPlugin<any>[] = [
+  logEntryActionsExtension,
+  extension
+];
+
+export default plugins;
+
+export {
+  ILogEntryAction,
+  ILogEntryActionMessage,
+  ILogEntryActionRegistry
+} from './logEntryActions';

--- a/src/logEntryActions.ts
+++ b/src/logEntryActions.ts
@@ -1,0 +1,464 @@
+import { LogConsolePanel, LogOutputModel } from '@jupyterlab/logconsole';
+
+import type { IOutputModel } from '@jupyterlab/rendermime';
+
+import { Token } from '@lumino/coreutils';
+
+import { DisposableDelegate, IDisposable } from '@lumino/disposable';
+
+import { ISignal, Signal } from '@lumino/signaling';
+
+const ACTIONS_CONTAINER_CLASS = 'jp-JSLogs-entryActions';
+const ACTION_BUTTON_CLASS = 'jp-JSLogs-entryActionButton';
+const OUTPUT_AREA_CLASS = 'jp-OutputArea';
+const OUTPUT_ITEM_CLASS = 'jp-OutputArea-child';
+const OUTPUT_CONTENT_CLASS = 'jp-OutputArea-output';
+
+type ISerializedLogOutput = Record<string, unknown>;
+
+/**
+ * The log message passed to action handlers.
+ */
+export interface ILogEntryActionMessage {
+  /**
+   * Source logger identifier.
+   */
+  source: string;
+
+  /**
+   * Position in the source log model.
+   */
+  entryIndex: number;
+
+  /**
+   * Log level as stored in the log model.
+   */
+  level: string;
+
+  /**
+   * Entry timestamp when available.
+   */
+  timestamp: Date | null;
+
+  /**
+   * Best-effort text extracted from the output payload.
+   */
+  text: string;
+
+  /**
+   * Raw output payload for integrations that need full context.
+   */
+  output: ISerializedLogOutput;
+}
+
+/**
+ * Action metadata for log entry actions.
+ */
+export interface ILogEntryAction {
+  /**
+   * Stable identifier for this action.
+   */
+  id: string;
+
+  /**
+   * Label shown in the action button.
+   */
+  label: string;
+
+  /**
+   * Optional tooltip.
+   */
+  caption?: string;
+
+  /**
+   * Optional visibility predicate.
+   */
+  isVisible?: (message: ILogEntryActionMessage) => boolean;
+
+  /**
+   * Action callback.
+   */
+  execute: (message: ILogEntryActionMessage) => void | Promise<void>;
+}
+
+/**
+ * Registry for actions shown on log entries.
+ */
+export interface ILogEntryActionRegistry extends IDisposable {
+  /**
+   * Signal emitted when actions are added/removed or updated.
+   */
+  readonly changed: ISignal<this, void>;
+
+  /**
+   * Register an action.
+   */
+  register(action: ILogEntryAction): IDisposable;
+
+  /**
+   * Whether any actions are currently registered.
+   */
+  hasActions(): boolean;
+
+  /**
+   * Get actions for a given log message.
+   */
+  getActions(message: ILogEntryActionMessage): ReadonlyArray<ILogEntryAction>;
+}
+
+/**
+ * Token for the log entry action registry.
+ */
+export const ILogEntryActionRegistry = new Token<ILogEntryActionRegistry>(
+  'jupyterlab-js-logs:ILogEntryActionRegistry'
+);
+
+/**
+ * Default in-memory action registry.
+ */
+export class LogEntryActionRegistry implements ILogEntryActionRegistry {
+  get changed(): ISignal<this, void> {
+    return this._changed;
+  }
+
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this._actions.clear();
+    Signal.clearData(this);
+  }
+
+  register(action: ILogEntryAction): IDisposable {
+    if (this._isDisposed) {
+      throw new Error('Log entry action registry is disposed.');
+    }
+    const actionId = action.id.trim();
+    if (actionId === '') {
+      throw new Error('Log entry action id cannot be empty.');
+    }
+    if (this._actions.has(actionId)) {
+      throw new Error(`Log entry action "${actionId}" is already registered.`);
+    }
+
+    this._actions.set(actionId, action);
+    this._changed.emit(void 0);
+
+    return new DisposableDelegate(() => {
+      const current = this._actions.get(actionId);
+      if (current === action) {
+        this._actions.delete(actionId);
+        this._changed.emit(void 0);
+      }
+    });
+  }
+
+  hasActions(): boolean {
+    return this._actions.size > 0;
+  }
+
+  getActions(message: ILogEntryActionMessage): ReadonlyArray<ILogEntryAction> {
+    return [...this._actions.values()]
+      .filter(action => this._isActionVisible(action, message))
+      .sort((left, right) => {
+        if (left.id === right.id) {
+          return 0;
+        }
+        return left.id < right.id ? -1 : 1;
+      });
+  }
+
+  private _isActionVisible(
+    action: ILogEntryAction,
+    message: ILogEntryActionMessage
+  ): boolean {
+    if (!action.isVisible) {
+      return true;
+    }
+    try {
+      return action.isVisible(message);
+    } catch (error) {
+      console.error(`Failed to evaluate visibility for "${action.id}".`, error);
+      return false;
+    }
+  }
+
+  private _isDisposed = false;
+  private _changed = new Signal<this, void>(this);
+  private _actions = new Map<string, ILogEntryAction>();
+}
+
+/**
+ * Renders registered actions on log entries.
+ */
+export class LogEntryActionsRenderer implements IDisposable {
+  constructor(options: LogEntryActionsRenderer.IOptions) {
+    this._panel = options.panel;
+    this._registry = options.registry;
+
+    this._panel.sourceChanged.connect(this._scheduleRender, this);
+    this._panel.sourceDisplayed.connect(this._scheduleRender, this);
+    this._registry.changed.connect(this._onRegistryChanged, this);
+
+    this._scheduleRender();
+  }
+
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+
+    this._clearActions();
+
+    this._panel.sourceChanged.disconnect(this._scheduleRender, this);
+    this._panel.sourceDisplayed.disconnect(this._scheduleRender, this);
+    this._registry.changed.disconnect(this._onRegistryChanged, this);
+  }
+
+  private _onRegistryChanged = (): void => {
+    this._registryRevision++;
+    this._scheduleRender();
+  };
+
+  private _scheduleRender = (): void => {
+    if (this._renderScheduled || this._isDisposed) {
+      return;
+    }
+    this._renderScheduled = true;
+    requestAnimationFrame(() => {
+      this._renderScheduled = false;
+      if (!this._isDisposed) {
+        this._render();
+      }
+    });
+  };
+
+  private _render(): void {
+    const source = this._panel.source;
+    const logger = this._panel.logger;
+    if (!source || !logger) {
+      this._clearActions();
+      return;
+    }
+    if (
+      this._lastRenderedSource === source &&
+      this._lastRenderedLoggerVersion === logger.version &&
+      this._lastRenderedRegistryRevision === this._registryRevision
+    ) {
+      return;
+    }
+
+    this._clearActions();
+    if (!this._registry.hasActions()) {
+      this._lastRenderedSource = source;
+      this._lastRenderedLoggerVersion = logger.version;
+      this._lastRenderedRegistryRevision = this._registryRevision;
+      return;
+    }
+
+    const outputArea = this._findVisibleOutputArea();
+    if (!outputArea) {
+      return;
+    }
+
+    const entries = logger.outputAreaModel;
+    const outputItems = this._getOutputItems(outputArea);
+    const count = Math.min(entries.length, outputItems.length);
+
+    for (let index = 0; index < count; index++) {
+      const message = this._toMessage(source, entries.get(index), index);
+      const actions = this._registry.getActions(message);
+      if (actions.length === 0) {
+        continue;
+      }
+
+      const outputNode = this._findOutputNode(outputItems[index]);
+      if (!outputNode) {
+        continue;
+      }
+
+      const container = this._createActionsContainer(actions, message);
+      if (container.childElementCount > 0) {
+        outputNode.appendChild(container);
+      }
+    }
+
+    this._lastRenderedSource = source;
+    this._lastRenderedLoggerVersion = logger.version;
+    this._lastRenderedRegistryRevision = this._registryRevision;
+  }
+
+  private _clearActions(): void {
+    this._panel.node
+      .querySelectorAll(`.${ACTIONS_CONTAINER_CLASS}`)
+      .forEach(node => node.remove());
+  }
+
+  private _findVisibleOutputArea(): HTMLElement | null {
+    const outputAreas = Array.from(
+      this._panel.node.getElementsByClassName(OUTPUT_AREA_CLASS)
+    );
+    for (const area of outputAreas) {
+      if (area instanceof HTMLElement && area.offsetParent !== null) {
+        return area;
+      }
+    }
+    return null;
+  }
+
+  private _getOutputItems(outputArea: HTMLElement): HTMLElement[] {
+    return Array.from(outputArea.children).filter(
+      node =>
+        node instanceof HTMLElement &&
+        node.classList.contains(OUTPUT_ITEM_CLASS)
+    ) as HTMLElement[];
+  }
+
+  private _findOutputNode(outputItem: HTMLElement): HTMLElement | null {
+    for (const child of Array.from(outputItem.children)) {
+      if (
+        child instanceof HTMLElement &&
+        child.classList.contains(OUTPUT_CONTENT_CLASS)
+      ) {
+        return child;
+      }
+    }
+    return null;
+  }
+
+  private _toMessage(
+    source: string,
+    outputModel: IOutputModel,
+    entryIndex: number
+  ): ILogEntryActionMessage {
+    const level =
+      outputModel instanceof LogOutputModel ? outputModel.level : 'unknown';
+    const timestamp =
+      outputModel instanceof LogOutputModel ? outputModel.timestamp : null;
+
+    const output = serializeOutput(outputModel, level, timestamp);
+
+    return {
+      source,
+      entryIndex,
+      level,
+      timestamp,
+      text: extractText(output),
+      output
+    };
+  }
+
+  private _createActionsContainer(
+    actions: ReadonlyArray<ILogEntryAction>,
+    message: ILogEntryActionMessage
+  ): HTMLDivElement {
+    const container = document.createElement('div');
+    container.className = ACTIONS_CONTAINER_CLASS;
+
+    for (const action of actions) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = ACTION_BUTTON_CLASS;
+      button.textContent = action.label;
+      button.title = action.caption ?? action.label;
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        event.stopPropagation();
+        this._executeAction(action, message);
+      });
+      container.appendChild(button);
+    }
+
+    return container;
+  }
+
+  private _executeAction(
+    action: ILogEntryAction,
+    message: ILogEntryActionMessage
+  ): void {
+    try {
+      const result = action.execute(message);
+      if (result && typeof (result as Promise<void>).catch === 'function') {
+        void (result as Promise<void>).catch(error => {
+          console.error(
+            `Failed to run log entry action "${action.id}".`,
+            error
+          );
+        });
+      }
+    } catch (error) {
+      console.error(`Failed to run log entry action "${action.id}".`, error);
+    }
+  }
+
+  private _isDisposed = false;
+  private _renderScheduled = false;
+  private _registryRevision = 0;
+  private _lastRenderedSource: string | null = null;
+  private _lastRenderedLoggerVersion: number | null = null;
+  private _lastRenderedRegistryRevision = -1;
+  private _panel: LogConsolePanel;
+  private _registry: ILogEntryActionRegistry;
+}
+
+export namespace LogEntryActionsRenderer {
+  export interface IOptions {
+    panel: LogConsolePanel;
+    registry: ILogEntryActionRegistry;
+  }
+}
+
+function extractText(output: ISerializedLogOutput): string {
+  const data =
+    typeof output.data === 'object' &&
+    output.data !== null &&
+    !Array.isArray(output.data)
+      ? (output.data as Record<string, unknown>)
+      : null;
+  if (data && typeof data['text/plain'] === 'string') {
+    return data['text/plain'];
+  }
+
+  return '';
+}
+
+function serializeOutput(
+  outputModel: IOutputModel,
+  level: string,
+  timestamp: Date | null
+): ISerializedLogOutput {
+  const output: ISerializedLogOutput = {
+    output_type: outputModel.type,
+    data:
+      typeof outputModel.data === 'object' &&
+      outputModel.data !== null &&
+      !Array.isArray(outputModel.data)
+        ? (outputModel.data as Record<string, unknown>)
+        : {},
+    metadata:
+      typeof outputModel.metadata === 'object' &&
+      outputModel.metadata !== null &&
+      !Array.isArray(outputModel.metadata)
+        ? (outputModel.metadata as Record<string, unknown>)
+        : {}
+  };
+
+  if (level !== 'unknown') {
+    output.level = level;
+  }
+  if (timestamp) {
+    output.timestamp = timestamp.getTime();
+  }
+
+  return output;
+}

--- a/src/logEntryActions.ts
+++ b/src/logEntryActions.ts
@@ -151,12 +151,14 @@ export class LogEntryActionRegistry implements ILogEntryActionRegistry {
       throw new Error(`Log entry action "${actionId}" is already registered.`);
     }
 
-    this._actions.set(actionId, action);
+    const storedAction =
+      actionId === action.id ? action : { ...action, id: actionId };
+    this._actions.set(actionId, storedAction);
     this._changed.emit(void 0);
 
     return new DisposableDelegate(() => {
       const current = this._actions.get(actionId);
-      if (current === action) {
+      if (current === storedAction) {
         this._actions.delete(actionId);
         this._changed.emit(void 0);
       }
@@ -409,13 +411,19 @@ export class LogEntryActionsRenderer implements IDisposable {
   }
 
   private _showSuccessState(button: HTMLButtonElement): void {
+    const previousTimer = this._successTimers.get(button);
+    if (previousTimer !== undefined) {
+      window.clearTimeout(previousTimer);
+    }
+
     button.classList.remove(ACTION_SUCCESS_CLASS);
     void button.offsetWidth;
     button.classList.add(ACTION_SUCCESS_CLASS);
 
-    window.setTimeout(() => {
+    const timer = window.setTimeout(() => {
       button.classList.remove(ACTION_SUCCESS_CLASS);
     }, ACTION_SUCCESS_DURATION_MS);
+    this._successTimers.set(button, timer);
   }
 
   private _isDisposed = false;
@@ -424,6 +432,7 @@ export class LogEntryActionsRenderer implements IDisposable {
   private _lastRenderedSource: string | null = null;
   private _lastRenderedLoggerVersion: number | null = null;
   private _lastRenderedRegistryRevision = -1;
+  private _successTimers = new WeakMap<HTMLButtonElement, number>();
   private _panel: LogConsolePanel;
   private _registry: ILogEntryActionRegistry;
 }

--- a/src/logEntryActions.ts
+++ b/src/logEntryActions.ts
@@ -12,7 +12,6 @@ const ACTIONS_CONTAINER_CLASS = 'jp-JSLogs-entryActions';
 const ACTION_BUTTON_CLASS = 'jp-JSLogs-entryActionButton';
 const OUTPUT_AREA_CLASS = 'jp-OutputArea';
 const OUTPUT_ITEM_CLASS = 'jp-OutputArea-child';
-const OUTPUT_CONTENT_CLASS = 'jp-OutputArea-output';
 
 type ISerializedLogOutput = Record<string, unknown>;
 
@@ -39,11 +38,6 @@ export interface ILogEntryActionMessage {
    * Entry timestamp when available.
    */
   timestamp: Date | null;
-
-  /**
-   * Best-effort text extracted from the output payload.
-   */
-  text: string;
 
   /**
    * Raw output payload for integrations that need full context.
@@ -282,14 +276,9 @@ export class LogEntryActionsRenderer implements IDisposable {
         continue;
       }
 
-      const outputNode = this._findOutputNode(outputItems[index]);
-      if (!outputNode) {
-        continue;
-      }
-
       const container = this._createActionsContainer(actions, message);
       if (container.childElementCount > 0) {
-        outputNode.appendChild(container);
+        outputItems[index].appendChild(container);
       }
     }
 
@@ -324,18 +313,6 @@ export class LogEntryActionsRenderer implements IDisposable {
     ) as HTMLElement[];
   }
 
-  private _findOutputNode(outputItem: HTMLElement): HTMLElement | null {
-    for (const child of Array.from(outputItem.children)) {
-      if (
-        child instanceof HTMLElement &&
-        child.classList.contains(OUTPUT_CONTENT_CLASS)
-      ) {
-        return child;
-      }
-    }
-    return null;
-  }
-
   private _toMessage(
     source: string,
     outputModel: IOutputModel,
@@ -346,14 +323,13 @@ export class LogEntryActionsRenderer implements IDisposable {
     const timestamp =
       outputModel instanceof LogOutputModel ? outputModel.timestamp : null;
 
-    const output = serializeOutput(outputModel, level, timestamp);
+    const output = serializeOutput(outputModel);
 
     return {
       source,
       entryIndex,
       level,
       timestamp,
-      text: extractText(output),
       output
     };
   }
@@ -368,7 +344,7 @@ export class LogEntryActionsRenderer implements IDisposable {
     for (const action of actions) {
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = ACTION_BUTTON_CLASS;
+      button.className = `${ACTION_BUTTON_CLASS} jp-Button jp-mod-minimal`;
       button.textContent = action.label;
       button.title = action.caption ?? action.label;
       button.addEventListener('click', event => {
@@ -418,25 +394,7 @@ export namespace LogEntryActionsRenderer {
   }
 }
 
-function extractText(output: ISerializedLogOutput): string {
-  const data =
-    typeof output.data === 'object' &&
-    output.data !== null &&
-    !Array.isArray(output.data)
-      ? (output.data as Record<string, unknown>)
-      : null;
-  if (data && typeof data['text/plain'] === 'string') {
-    return data['text/plain'];
-  }
-
-  return '';
-}
-
-function serializeOutput(
-  outputModel: IOutputModel,
-  level: string,
-  timestamp: Date | null
-): ISerializedLogOutput {
+function serializeOutput(outputModel: IOutputModel): ISerializedLogOutput {
   const output: ISerializedLogOutput = {
     output_type: outputModel.type,
     data:
@@ -452,13 +410,6 @@ function serializeOutput(
         ? (outputModel.metadata as Record<string, unknown>)
         : {}
   };
-
-  if (level !== 'unknown') {
-    output.level = level;
-  }
-  if (timestamp) {
-    output.timestamp = timestamp.getTime();
-  }
 
   return output;
 }

--- a/src/logEntryActions.ts
+++ b/src/logEntryActions.ts
@@ -1,6 +1,8 @@
 import { LogConsolePanel, LogOutputModel } from '@jupyterlab/logconsole';
 
 import type { IOutputModel } from '@jupyterlab/rendermime';
+import { checkIcon } from '@jupyterlab/ui-components';
+import type { LabIcon } from '@jupyterlab/ui-components';
 
 import { Token } from '@lumino/coreutils';
 
@@ -10,6 +12,10 @@ import { ISignal, Signal } from '@lumino/signaling';
 
 const ACTIONS_CONTAINER_CLASS = 'jp-JSLogs-entryActions';
 const ACTION_BUTTON_CLASS = 'jp-JSLogs-entryActionButton';
+const ACTION_ICON_CLASS = 'jp-JSLogs-entryActionIcon';
+const ACTION_SUCCESS_ICON_CLASS = 'jp-JSLogs-entryActionSuccessIcon';
+const ACTION_SUCCESS_CLASS = 'jp-mod-success';
+const ACTION_SUCCESS_DURATION_MS = 900;
 const OUTPUT_AREA_CLASS = 'jp-OutputArea';
 const OUTPUT_ITEM_CLASS = 'jp-OutputArea-child';
 
@@ -55,14 +61,19 @@ export interface ILogEntryAction {
   id: string;
 
   /**
-   * Label shown in the action button.
+   * Optional label shown in the action button.
    */
-  label: string;
+  label?: string;
 
   /**
    * Optional tooltip.
    */
   caption?: string;
+
+  /**
+   * Optional icon shown before the label.
+   */
+  icon?: LabIcon;
 
   /**
    * Optional visibility predicate.
@@ -345,12 +356,38 @@ export class LogEntryActionsRenderer implements IDisposable {
       const button = document.createElement('button');
       button.type = 'button';
       button.className = `${ACTION_BUTTON_CLASS} jp-Button jp-mod-minimal`;
-      button.textContent = action.label;
-      button.title = action.caption ?? action.label;
+      const caption = action.caption ?? action.label ?? action.id;
+      button.title = caption;
+      button.setAttribute('aria-label', caption);
+
+      if (action.icon) {
+        const icon = action.icon.element({
+          tag: 'span',
+          className: ACTION_ICON_CLASS,
+          elementSize: 'normal'
+        });
+        icon.setAttribute('aria-hidden', 'true');
+        button.appendChild(icon);
+      }
+
+      if (action.label) {
+        const label = document.createElement('span');
+        label.textContent = action.label;
+        button.appendChild(label);
+      }
+
+      const successIcon = checkIcon.element({
+        tag: 'span',
+        className: ACTION_SUCCESS_ICON_CLASS,
+        elementSize: 'normal'
+      });
+      successIcon.setAttribute('aria-hidden', 'true');
+      button.appendChild(successIcon);
+
       button.addEventListener('click', event => {
         event.preventDefault();
         event.stopPropagation();
-        this._executeAction(action, message);
+        void this._executeAction(action, message, button);
       });
       container.appendChild(button);
     }
@@ -358,23 +395,27 @@ export class LogEntryActionsRenderer implements IDisposable {
     return container;
   }
 
-  private _executeAction(
+  private async _executeAction(
     action: ILogEntryAction,
-    message: ILogEntryActionMessage
-  ): void {
+    message: ILogEntryActionMessage,
+    button: HTMLButtonElement
+  ): Promise<void> {
     try {
-      const result = action.execute(message);
-      if (result && typeof (result as Promise<void>).catch === 'function') {
-        void (result as Promise<void>).catch(error => {
-          console.error(
-            `Failed to run log entry action "${action.id}".`,
-            error
-          );
-        });
-      }
+      await action.execute(message);
+      this._showSuccessState(button);
     } catch (error) {
       console.error(`Failed to run log entry action "${action.id}".`, error);
     }
+  }
+
+  private _showSuccessState(button: HTMLButtonElement): void {
+    button.classList.remove(ACTION_SUCCESS_CLASS);
+    void button.offsetWidth;
+    button.classList.add(ACTION_SUCCESS_CLASS);
+
+    window.setTimeout(() => {
+      button.classList.remove(ACTION_SUCCESS_CLASS);
+    }, ACTION_SUCCESS_DURATION_MS);
   }
 
   private _isDisposed = false;

--- a/style/base.css
+++ b/style/base.css
@@ -5,10 +5,12 @@
 */
 
 .jp-JSLogs-entryActions {
-  display: flex;
-  flex-wrap: wrap;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
   gap: 4px;
-  margin-top: 4px;
+  margin: 2px 6px 2px 8px;
+  white-space: nowrap;
 }
 
 .jp-JSLogs-entryActionButton {
@@ -19,6 +21,7 @@
   padding: 1px 6px;
   min-height: 20px;
   cursor: pointer;
+  margin: 0;
 }
 
 .jp-JSLogs-entryActionButton:hover {

--- a/style/base.css
+++ b/style/base.css
@@ -5,9 +5,11 @@
 */
 
 .jp-JSLogs-entryActions {
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
   flex: 0 0 auto;
   align-items: center;
+  justify-content: center;
   gap: 4px;
   margin: 2px 6px 2px 8px;
   white-space: nowrap;
@@ -15,15 +17,9 @@
 
 .jp-JSLogs-entryActionButton {
   border: 1px solid var(--jp-border-color2);
-  border-radius: var(--jp-border-radius);
-  background: var(--jp-layout-color1);
-  color: var(--jp-ui-font-color1);
   padding: 1px 6px;
   min-height: 20px;
   cursor: pointer;
-  margin: 0;
-  gap: 4px;
-  position: relative;
 }
 
 .jp-JSLogs-entryActionButton:hover {

--- a/style/base.css
+++ b/style/base.css
@@ -20,6 +20,7 @@
   padding: 1px 6px;
   min-height: 20px;
   cursor: pointer;
+  position: relative;
 }
 
 .jp-JSLogs-entryActionButton:hover {

--- a/style/base.css
+++ b/style/base.css
@@ -22,8 +22,32 @@
   min-height: 20px;
   cursor: pointer;
   margin: 0;
+  gap: 4px;
+  position: relative;
 }
 
 .jp-JSLogs-entryActionButton:hover {
   background: var(--jp-layout-color2);
+}
+
+.jp-JSLogs-entryActionIcon,
+.jp-JSLogs-entryActionSuccessIcon {
+  transition: opacity 140ms ease;
+}
+
+.jp-JSLogs-entryActionSuccessIcon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.jp-JSLogs-entryActionButton.jp-mod-success .jp-JSLogs-entryActionIcon {
+  opacity: 0;
+}
+
+.jp-JSLogs-entryActionButton.jp-mod-success .jp-JSLogs-entryActionSuccessIcon {
+  opacity: 1;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -3,3 +3,24 @@
 
     https://jupyterlab.readthedocs.io/en/stable/developer/css.html
 */
+
+.jp-JSLogs-entryActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.jp-JSLogs-entryActionButton {
+  border: 1px solid var(--jp-border-color2);
+  border-radius: var(--jp-border-radius);
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+  padding: 1px 6px;
+  min-height: 20px;
+  cursor: pointer;
+}
+
+.jp-JSLogs-entryActionButton:hover {
+  background: var(--jp-layout-color2);
+}


### PR DESCRIPTION
Refs: https://github.com/jupyterlab/plugin-playground/issues/194

This PR adds a log-entry actions extension point, allowing external extensions to register custom per-row action buttons and callbacks through `ILogEntryActionRegistry`. It wires action rendering into the JS Logs panel.