### PR TITLE
Fix text overlap transition on buttons

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -27,8 +27,7 @@
   background: var(--jp-layout-color2);
 }
 
-.jp-JSLogs-entryActionIcon,
-.jp-JSLogs-entryActionSuccessIcon {
+.jp-JSLogs-entryActionButton > span {
   transition: opacity 140ms ease;
 }
 
@@ -41,7 +40,8 @@
   pointer-events: none;
 }
 
-.jp-JSLogs-entryActionButton.jp-mod-success .jp-JSLogs-entryActionIcon {
+.jp-JSLogs-entryActionButton.jp-mod-success
+  > :not(.jp-JSLogs-entryActionSuccessIcon) {
   opacity: 0;
 }
 


### PR DESCRIPTION
Ref: https://github.com/jupyterlab/plugin-playground/pull/231#issuecomment-4478175231

Earlier, on success, CSS only fades the normal action icon, but does not hide the text label, This PR fixes it by adding a transition to the span element instead of the icon.


https://github.com/user-attachments/assets/82024a91-1d5e-451d-9b85-e298053967c0

